### PR TITLE
Removes verbiage from -c option

### DIFF
--- a/scrape.sh
+++ b/scrape.sh
@@ -26,7 +26,6 @@ Examples:
 ./scrape.sh -t 8.8.8.8 -a
 ./scrape.sh -t 8.8.8.8 -o
 ./scrape.sh -t 8.8.8.8 -u
-./scrape.sh -t 8.8.8.8 -c
 ./scrape.sh -t 8.8.8.8 -i custom_sites.list
 
 OPTIONS:


### PR DESCRIPTION
```
./scrape.sh -t 8.8.8.8 -c
```

Was referenced previously but there is no actual code to handle -c and it appears to have been moved over to -i (assuming -c used to stand for custom)
